### PR TITLE
Exams retiring december 2018

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -191,9 +191,9 @@ When you have learned all the fundamentals in Azure you can move on to the paid 
 
 #### Certification Exams
 * [Cloud Fundamentals - Exam 98-369](https://www.microsoft.com/en-us/learning/exam-98-369.aspx)
-* [Developing Microsoft Azure Solutions - Exam 70-532](https://www.microsoft.com/en-us/learning/course.aspx?cid=20532)
-* [Implementing Microsoft Azure Infrastructure Solutions - Exam 70-533](https://www.microsoft.com/en-us/learning/course.aspx?cid=20533)
-* [Architecting Microsoft Azure Solutions - Exam 70-534](https://www.microsoft.com/en-us/learning/course.aspx?cid=40442)
+* [Microsoft Certified Azure Developer (Replaced Exam 70-532)](https://www.microsoft.com/en-us/learning/azure-developer.aspx)
+* [Microsoft Certified Azure Administrator (Replaced Exam 70-533)](https://www.microsoft.com/en-us/learning/course.aspx?cid=20533)
+* [Microsoft Certified Azure Solutions Architect (Replaced Exam 70-534)](https://www.microsoft.com/en-us/learning/course.aspx?cid=40442)
 * [Designing and Implementing Cloud Data Platform Solutions - Exam 70-473](https://www.microsoft.com/en-us/learning/exam-70-473.aspx)
 * [Designing and Implementing Big Data Analytics Solutions - Exam 70-475](https://www.microsoft.com/en-us/learning/exam-70-475.aspx)
 * [Monitoring and Operating a Private Cloud - Exam 70-246](https://www.microsoft.com/en-us/learning/exam-70-246.aspx)


### PR DESCRIPTION
Exams retiring December 2018, replaced with new role based exams announced in Microsoft Ignite Conference 2018.
See [this link](https://www.microsoft.com/en-us/learning/browse-new-certification.aspx) for more.